### PR TITLE
Add a simple HTML landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,435 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Welcome to nelson.social</title>
+    <!-- <link rel="stylesheet" href="https://cdn.simplecss.org/simple.min.css"> -->
+    <!-- <link rel="stylesheet" href="https://unpkg.com/chota@latest"> -->
+    <!-- <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/pure-min.css" integrity="sha384-X38yfunGUhNzHpBaEBsWLO+A0HDYOQi8ufWDkZ0k9e0eXz/tH3II7uKZ9msv++Ls" crossorigin="anonymous"> -->
+    <link rel="stylesheet" href="https://unpkg.com/mvp.css@1.12/mvp.css" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
+  <body>
+    <header>
+      <nav>
+        <ul>
+          <li>
+            <a href="#about">About</a>
+          </li>
+          <li>
+            <a href="#land">Land Acknowledgement</a>
+          </li>
+          <li>
+            <a href="#conduct">Code of conduct</a>
+          </li>
+          <li>
+            <a href="#team">Team</a>
+          </li>
+        </ul>
+      </nav>
+      <h1>Welcome to nelson.social</h1>
+      <p>An online community for the lovely people of Nelson, BC</p>
+      <p>
+        <a href="https://nelson.social/auth/sign_up">
+          <b>Create an account</b>
+        </a>
+        <a href="https://nelson.social/auth/sign_in">
+          <i>Sign in</i>
+        </a>
+      </p>
+    </header>
+    <main>
+      <article>
+        <h2 id="about">About nelson.social</h2>
+        <p>
+          Welcome to nelson.social, an online space dedicated to the community
+          of Nelson, BC! We’re excited to build a place where people from all
+          walks of life can come together to share ideas and passions, build
+          connections, or just hang out and chat.
+        </p>
+        <p>
+          Here at nelson.social, we believe in the power of community and the
+          importance of supporting one another in order to enrich our community.
+          Whether you are a lifelong resident of Nelson, new to the region, or
+          just passing through, we invite you to join the conversation and be a
+          part of our community.
+        </p>
+        <p>
+          In this space, you can share your thoughts and ideas, ask questions of
+          your neighbours, and even plan events and activities. You can also
+          connect with people from all over the world, because nelson.social is
+          part of the
+          <a href="https://github.com/mastodon/">Mastodon</a> network. We like
+          to think of it like a big WhatsApp or iMessage group, but where you
+          can choose who to share with and whose messages you see, even if they
+          aren’t members of nelson.social.
+        </p>
+        <p>
+          We expect our members to be respectful and considerate of others, and
+          to use this space to help build a stronger, more connected community
+          in Nelson. We have a simple set of rules for the space that help the
+          team that runs nelson.social ensure that we can be welcoming for
+          everyone. Please read them, and reach out to us if you encounter any
+          problems, or have any questions.
+        </p>
+        <p>
+          We look forward to seeing you on nelson.social, and to building a
+          vibrant and supportive community together. Welcome!
+        </p>
+        <h2 id="land">Land Acknowledgement</h2>
+        <p>
+          We would like to acknowledge that in Nelson we live and work on the
+          traditional, ancestral and unceded territory of Sinixt Peoples. We
+          make this acknowledgment to show our respect for the tmxʷulaʔxʷ
+          (homeland), and
+          <a href="https://bloodoflifecollective.org/sinixt.html" rel="nofollow"
+            >Sinixt</a
+          >
+          Nation. We feel privileged and grateful to be here, and we invite
+          those reading this to explore their own relationship to place.
+        </p>
+        <h2 id="conduct">Code of Conduct</h2>
+        <p>
+          Nelson is home to people from all over the world who have a diverse
+          set of skills, personalities, backgrounds and experiences. This
+          diversity is wonderful, and we are committed to ensuring that the
+          nelson.social community is a safe, enjoyable and thriving environment
+          for the largest number possible of Nelson residents, their friends and
+          family members.
+        </p>
+        <p>
+          To that end, we will strive to make this a friendly, safe and
+          welcoming environment for everyone regardless of qualities such as
+          their gender identity or expression, sexual orientation, disability,
+          mental illness, neuro(a)typicality, physical appearance, body size,
+          age, race, nationality, ethnicity, socioeconomic status, family
+          structure, spirituality, religion (or lack thereof), education, or
+          other personal traits. We particularly celebrate diversity and do not
+          tolerate bigotry or prejudice.
+        </p>
+        <p>
+          As a community, we expect any participant to act according to the
+          guidelines in this document. They ensure that everyone within the
+          community is clear about the behaviour that is expected of them, and
+          that newcomers know what kind of environment they can expect to find
+          here.
+        </p>
+        <p>
+          This is a living document, and the&nbsp;nelson.social
+          team&nbsp;welcome your feedback. We will amend this document as
+          necessary to ensure the safety of our users.
+        </p>
+        <h3>Guiding principle</h3>
+        <p>
+          <em
+            >If you wouldn't do it in Oso Negro, don't do it on
+            nelson.social</em
+          >
+        </p>
+        <h3>Handling conflict</h3>
+        <p>
+          A diverse group of people has a diverse set of boundaries about what
+          is OK. Sometimes one of us may make a mistake, and do something that
+          inadvertently causes offence. When we observe this happen, we try to
+          give the offender feedback quickly, clearly and constructively. We try
+          to offer them the opportunity to maintain their dignity in the
+          situation, to learn from and repair their mistake.
+        </p>
+        <p>
+          This kind of learning and repair is how we strengthen our
+          relationships and our community. However we will not tolerate anyone
+          deliberately or repeatedly breaking these rules.
+        </p>
+        <h3>Consequences of Unacceptable Behavior</h3>
+        <p>
+          Unacceptable behavior from any community member, including those with
+          decision-making authority, will not be tolerated.
+        </p>
+        <p>
+          Anyone asked to stop unacceptable behavior is expected to comply
+          immediately.
+        </p>
+        <p>
+          If a community member engages in unacceptable behavior, the community
+          organizers may take any action they deem appropriate, up to and
+          including a temporary suspension or permanent ban from the community
+          without warning.
+        </p>
+        <h3>Reporting Guidelines</h3>
+        <p>
+          If you are subject to or witness unacceptable behavior, please use the
+          "Report user" functionality of Mastodon. If the situation is beyond
+          unacceptable behavior, please notify any of the
+          <a href="#team">Team</a> via direct message. We are here to help you.
+          Your reports will be taken seriously, treated in confidence and will
+          not be dismissed or argued with.
+        </p>
+        <p>
+          Additionally, community organizers are available to help community
+          members engage with local law enforcement or to otherwise help those
+          experiencing unacceptable behavior feel safe.
+        </p>
+        <h3>Goals</h3>
+        <ol>
+          <li>
+            Provide a safe and welcoming community space for discussing Nelson
+            &amp; area activities, news, events, and experiences.
+          </li>
+          <li>
+            Provide a venue for both casual and serious conversation, with the
+            ability for users to opt-out of unwanted content.
+          </li>
+          <li>
+            Fun! We aim to foster a community of individuals and business that
+            love being here in the Kootenays. We welcome personal posts, event
+            notices and organizing.
+          </li>
+        </ol>
+        <h3>Non-Goals</h3>
+        <p>
+          While it's important to know what nelson.social is, it's just as
+          important to understand what nelson.social is not. Nelson.social is
+          not:
+        </p>
+        <ul>
+          <li>
+            A money-making exercise. This is a community-run website, made of
+            open-source software, hosted and moderated by volunteers who live in
+            your community. We are not going to
+            <a
+              href="https://en.wikipedia.org/wiki/Facebook%E2%80%93Cambridge_Analytica_data_scandal"
+              rel="nofollow"
+              >sell your data</a
+            >, or try to get you
+            <a
+              href="https://www.theguardian.com/technology/2017/nov/09/facebook-sean-parker-vulnerability-brain-psychology"
+              rel="nofollow"
+              >addicted</a
+            >
+            so that we can show you more ads. In fact, there are no ads!
+          </li>
+          <li>
+            A "free speech" zone. We encourage authentic, curious, respectful
+            conversation, including disagreement, but we do not tolerate all
+            forms of speech. We do not tolerate hate speech
+            of&nbsp;any&nbsp;kind.
+            <a href="https://en.wikipedia.org/wiki/Bad_faith" rel="nofollow"
+              >Bad-faith</a
+            >
+            debating is equally unwelcome, as is misinformation.
+          </li>
+          <li>
+            A place for general advertisement. Promoting your original work is
+            welcome, but please avoid overly commercial self-promotion
+          </li>
+        </ul>
+        <p>
+          You may
+          <a href="https://instances.social/" rel="nofollow"
+            >find another server</a
+          >
+          to be a better fit if you don't like these rules.
+        </p>
+        <h3>Encouraged Behavior</h3>
+        <p>
+          The following behaviors are expected and requested of all community
+          members:
+        </p>
+        <ul>
+          <li>Be friendly, open and welcoming.</li>
+          <li>
+            Participate in an authentic and active way. In doing so, you
+            contribute to the health and longevity of this community.
+          </li>
+          <li>
+            Exercise consideration and respect in your speech and actions.
+          </li>
+          <li>Attempt collaboration &amp; de-escalation before conflict.</li>
+          <li>
+            If you inadvertently cause offence to someone else, take
+            responsibility for your actions.
+          </li>
+          <li>
+            Refrain from demeaning, discriminatory, or harassing behavior and
+            speech.
+          </li>
+          <li>
+            Be mindful of your fellow participants. Alert community leaders if
+            you notice a dangerous situation, someone in distress, or violations
+            of this Code of Conduct, even if they seem inconsequential.
+          </li>
+        </ul>
+        <h3>Unacceptable Behavior</h3>
+        <p>
+          To be specific, the following behaviors are unacceptable within our
+          community:
+        </p>
+        <ul>
+          <li>
+            Anything in violation of our
+            <a href="https://nelson.social/terms" rel="nofollow"
+              >Terms of Service</a
+            >
+            including posting anything illegal in British Columbia or Canada.
+          </li>
+          <li>
+            Violence, threats of violence or violent language directed against
+            another person.
+          </li>
+          <li>
+            Using slurs or racist, sexist, homophobic, transphobic, ableist or
+            otherwise discriminatory or hateful jokes or language; promoting
+            white supremacy, anti-Semitism, transphobia, castism or other
+            hateful ideologies.
+          </li>
+          <li>Posting or displaying sexually explicit or violent material.</li>
+          <li>
+            Posting or threatening to post other people's personally identifying
+            information ("doxing").
+          </li>
+          <li>
+            Personal insults, particularly those related to gender, sexual
+            orientation, race, religion, or disability.
+          </li>
+          <li>
+            Unwelcome sexual attention. This includes, sexualized comments or
+            jokes; unwelcomed sexual advances.
+          </li>
+          <li>
+            Deliberate intimidation, stalking or following (online or in
+            person).
+          </li>
+          <li>
+            Debating moderation actions in public. If you disagree with how a
+            moderator enforced this Code of Conduct you may direct-message the
+            moderation team.
+          </li>
+          <li>
+            Tone policing. Messages you see on nelson.social may violate the
+            standards of civility we set on nelson.social, but you should not
+            criticize users for their tone. If the user is a member of the
+            nelson.social community, you should report them; if not, you should
+            feel free to block them. In neither case should you criticize their
+            tone.
+          </li>
+          <li>Advocating for, or encouraging, any of the above behavior.</li>
+        </ul>
+        <p>
+          Again, we suggest you
+          <a href="https://instances.social/" rel="nofollow"
+            >find another server</a
+          >
+          or even
+          <a href="https://runyourown.social/" rel="nofollow"
+            >set up your own</a
+          >
+          if you don't agree with these rules.
+        </p>
+        <h3>Addressing Grievances</h3>
+        <p>
+          If you feel you have been falsely or unfairly accused of violating
+          this Code of Conduct, you should notify
+          <a href="mailto:admin@nelson.social">admin@nelson.social</a> with a
+          concise description of your grievance. Your grievance will be handled
+          in due course by the moderation team.
+        </p>
+        <h3>Scope</h3>
+        <p>
+          We expect all community participants to abide by this Code of Conduct
+          in all community venues--online and in-person--as well as in all
+          one-on-one communications pertaining to community business.
+        </p>
+        <p>
+          This code of conduct and its related procedures also applies to
+          unacceptable behavior occurring outside the scope of community
+          activities when such behavior has the potential to adversely affect
+          the safety and well-being of community members.
+        </p>
+        <h3>License and attribution</h3>
+        <p>
+          The nelson.social Code of Conduct is distributed by
+          <a href="http://nelson.social" rel="nofollow">nelson.social</a> under
+          a
+          <a
+            href="http://creativecommons.org/licenses/by-sa/3.0/"
+            rel="nofollow"
+            >Creative Commons Attribution-ShareAlike license</a
+          >.
+        </p>
+        <p>Portions of text derived from:</p>
+        <ul>
+          <li>
+            <a href="https://www.djangoproject.com/conduct/" rel="nofollow"
+              >Django Code of Conduct</a
+            >
+          </li>
+          <li>
+            <a
+              href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy"
+              rel="nofollow"
+              >Geek Feminism Anti-Harassment Policy</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://wiki.social.coop/rules-and-bylaws/Code-of-conduct.html"
+              rel="nofollow"
+              >Social.coop Code of Conduct</a
+            >
+          </li>
+          <li>
+            <a href="https://hub.fosstodon.org/coc/" rel="nofollow"
+              >Fosstodon Code of Conduct</a
+            >
+          </li>
+          <li>
+            <a href="https://ottawa.place/terms#coc" rel="nofollow"
+              >Ottawa.place Code of Conduct</a
+            >
+          </li>
+          <li>
+            <a href="https://cucumber.io/conduct" rel="nofollow"
+              >Cucumber Community Code of Conduct</a
+            >
+          </li>
+        </ul>
+        <h2 id="team">Team</h2>
+        <p>
+          This server is hosted and run by a team of volunteers who live here in
+          Nelson, BC:
+        </p>
+        <ul>
+          <li>
+            <a href="https://nelson.social/@blaine" rel="nofollow">@blaine</a>
+          </li>
+          <li>
+            <a href="https://nelson.social/@matt" rel="nofollow">@matt</a>
+          </li>
+          <li>
+            <a href="https://nelson.social/@till" rel="nofollow">@till</a>
+          </li>
+        </ul>
+        <p>
+          We're well aware that we're three privileged white dudes (though only
+          one born-Canadian! Yay im/migration!) and while we are happy to
+          continue to pay for the costs of running the service and volunteer our
+          labour, we would like to diversify the team, divest ourselves of power
+          and would gladly welcome volunteers (and eventually paid staff, if
+          appropriate) to help or lead decision-making. Please get in touch if
+          you'd like to get involved!
+        </p>
+        <p>
+          Email <a href="mailto:admin@nelson.social">admin@nelson.social</a> to
+          contact us.
+        </p>
+      </article>
+    </main>
+
+    <footer>
+      <hr />
+      <nav>
+        <a href="https://nelson.social/privacy-policy">Privacy policy</a>
+      </nav>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
As part of an initiative discussed in Signal to get more flexibility for our landing page and make it more user-friendly for folks who don't know or care much about mastodon.

I've tried a few minimal CSS frameworks and settled on https://andybrewer.github.io/mvp/ for now, it seems to give us most what we want with the least amount of fuss.

The copy and styling isn't important right now, I just wanted to get a page up that's functional (good enough for now) so we can play with how we actually deploy it and do the cloudflare config etc.

I suggest we use GitHub pages to publish it at a URL, then we can get Cloudflare to read it from there. That will make it straightforward to deploy changes. WDYT?

Here's a preview: https://nelson-social.github.io/community/